### PR TITLE
chore: add python image to docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # build stage
 FROM node:alpine as build-stage
+RUN apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python
 WORKDIR /app
 COPY package*.json ./
 RUN npm install


### PR DESCRIPTION
Python is required for node-sass when running `npm install`